### PR TITLE
Use individual files instead of logout_worlds.yml

### DIFF
--- a/src/main/java/me/x128/xInventories/listener/LogInOutListener.java
+++ b/src/main/java/me/x128/xInventories/listener/LogInOutListener.java
@@ -2,14 +2,12 @@ package me.x128.xInventories.listener;
 
 import me.x128.xInventories.Main;
 import me.x128.xInventories.utils.InventoryInstance;
+import me.x128.xInventories.utils.LogoutGroup;
 import me.x128.xInventories.utils.PlayerUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 
 /**
@@ -24,28 +22,28 @@ public class LogInOutListener implements Listener {
     public void onLogout(PlayerQuitEvent ev) {
         String uuid = ev.getPlayer().getUniqueId().toString();
         String group = PlayerUtil.getPlayerCurrentGroup(ev.getPlayer());
-        Main.getLogoutGroup().setGroup(uuid, group, ev.getPlayer().getWorld().getName());
-        //Main.getLogoutGroup().save();
+        LogoutGroup lg = new LogoutGroup(uuid);
+        lg.setGroup(group, ev.getPlayer().getWorld().getName());
+        lg.save(true);
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent ev) {
         Player p = ev.getPlayer();
         String uuid = p.getUniqueId().toString();
+        LogoutGroup lg = new LogoutGroup(uuid);
 
-        String prevGroup = Main.getLogoutGroup().getGroup(uuid);
+        String prevGroup = lg.getGroup();
         String curGroup = PlayerUtil.getPlayerCurrentGroup(p);
 
-        String prevWorld = Main.getLogoutGroup().getWorld(uuid);
+        String prevWorld = lg.getWorld();
         String curWorld = p.getWorld().getName();
 
         if ((prevGroup != null && !curGroup.equalsIgnoreCase(prevGroup)) && (prevWorld != null && !curWorld.equalsIgnoreCase(prevWorld))) {
             if (Bukkit.getWorld(prevWorld) != null) {
                 return;
             }
-            Main.getPlugin().getConfig().getMapList("worlds");
             Main.getPlugin().getLogger().info(p.getName() + " has logged into an unloaded world");
-
             //switch player inventory groups
             InventoryInstance fromInv = new InventoryInstance(p);
             fromInv.setGroup(prevGroup);

--- a/src/main/java/me/x128/xInventories/utils/FileManager.java
+++ b/src/main/java/me/x128/xInventories/utils/FileManager.java
@@ -20,11 +20,11 @@ public class FileManager {
     public static void saveConfiguraton(final File f, final FileConfiguration fc, boolean respectAsync) {
         /**
          We now have two methods of saving, user configurable.
-         The regular way (and the safest way) is to save syncronously.
+         The regular way (and the safest way) is to save synchronously.
          This new method of async saving was added in 2.4 to appease
-         someone unsatisfied with syncronous performance.
+         someone unsatisfied with synchronous performance.
 
-         Option for async override is used only for saving the player logout file when plugin is disabled.
+         Option for async override is used only for converting logout_worlds.yml
          **/
 
         if (!Main.getPlugin().getConfig().getBoolean("save-async") || !respectAsync) {

--- a/src/main/java/me/x128/xInventories/utils/InventoryInstance.java
+++ b/src/main/java/me/x128/xInventories/utils/InventoryInstance.java
@@ -247,8 +247,8 @@ public class InventoryInstance {
         config.set("armor_contents.leggings", pants);
         config.set("armor_contents.boots", boots);
 
-        //save location
-        config.set("location", p.getLocation());
+        //save location - Not used, remove from old config
+        config.set("location", null);
 
         //save potions
         pos = 0;

--- a/src/main/java/me/x128/xInventories/utils/LogoutGroup.java
+++ b/src/main/java/me/x128/xInventories/utils/LogoutGroup.java
@@ -1,12 +1,9 @@
 package me.x128.xInventories.utils;
 
 import me.x128.xInventories.Main;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * Created by Cole on 4/26/16.
@@ -16,44 +13,32 @@ public class LogoutGroup {
     private FileConfiguration config;
     private File file;
 
-    public LogoutGroup() {
+    public LogoutGroup(String uuid) {
         //get the group file
-        file = new File(Main.getPlugin().getDataFolder() + File.separator + "logout_worlds.yml");
+        file = new File(Main.getPlugin().getDataFolder() + File.separator + "logout_worlds" + File.separator + uuid + ".yml");
         config = FileManager.getYaml(file);
-
-        //start autosave
-
-       new BukkitRunnable(){
-            @Override
-            public void run(){
-                save(true);
-            }
-        }.runTaskTimer(Main.getPlugin(), 0, 20 * 120);
-
     }
 
     public void save(boolean respectAsync) {
         FileManager.saveConfiguraton(file, config, respectAsync);
     }
 
-    public void setGroup(String uuid, String group, String world) {
-        config.set("v2-logout." + uuid + ".group", group);
-        config.set("v2-logout." + uuid + ".world", world);
+    public void setGroup(String group, String world) {
+        config.set("group", group);
+        config.set("world", world);
     }
 
-    public String getGroup(String uuid) {
-        if (config.contains("v2-logout." + uuid)) {
-            return config.getString("v2-logout." + uuid + ".group");
-        } else {
-            return null;
+    public String getGroup() {
+        if (config.contains("group")) {
+            return config.getString("group");
         }
+        return null;
     }
 
-    public String getWorld(String uuid) {
-        if (config.contains("v2-logout." + uuid)) {
-            return config.getString("v2-logout." + uuid + ".world");
-        } else {
-            return null;
+    public String getWorld() {
+        if (config.contains("world")) {
+            return config.getString("world");
         }
+        return null;
     }
 }


### PR DESCRIPTION
This PR eliminates the logout_worlds.yml file and the large time required to save it every two minutes. Instead, individual _uuid_.yml files are created in a new directory, logout_worlds. Files are saved when the users logout instead of periodically.

It also converts the existing data in logout_worlds.yml into the new individual files, then renames logout_worlds.yml to logout_worlds_OLD.yml. The server owner can then delete the renamed file.

The asynchronous saving option is still available, although with these small files it should no longer be necessary.

Fixes #2.